### PR TITLE
Migrate envvars

### DIFF
--- a/addon/adapters/api-response.js
+++ b/addon/adapters/api-response.js
@@ -3,7 +3,7 @@ import ENV from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
   host: ENV.wnycAPI,
-  namespace: 'api/v3',
+  namespace: 'v3',
   pathForType: () => 'channel',
   buildURL() {
     let url = this._super(...arguments);

--- a/addon/adapters/api-response.js
+++ b/addon/adapters/api-response.js
@@ -1,8 +1,8 @@
 import DS from 'ember-data';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v3',
   pathForType: () => 'channel',
   buildURL() {

--- a/addon/adapters/bucket.js
+++ b/addon/adapters/bucket.js
@@ -3,7 +3,7 @@ import ENV from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
   host: ENV.wnycAPI,
-  namespace: 'api/v3',
+  namespace: 'v3',
   buildURL(modelName, id, snapshot, requestType, query) {
     let url = this._super(...arguments);
     if (requestType !== 'findRecord') {

--- a/addon/adapters/bucket.js
+++ b/addon/adapters/bucket.js
@@ -1,8 +1,8 @@
 import DS from 'ember-data';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v3',
   buildURL(modelName, id, snapshot, requestType, query) {
     let url = this._super(...arguments);
@@ -10,7 +10,7 @@ export default DS.JSONAPIAdapter.extend({
       return url;
     }
 
-    url += `/?site=${ENV.siteSlug}`;
+    url += `/?site=${config.siteSlug}`;
     if (query && Object.keys(query).length) {
       let qp = Object.keys(query).map(k => `${k}=${query[k]}`);
       url += qp.join('&');

--- a/addon/adapters/channel.js
+++ b/addon/adapters/channel.js
@@ -4,7 +4,7 @@ import ENV from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
   host: ENV.wnycAPI,
-  namespace: 'api/v3',
+  namespace: 'v3',
   pathForType: () => 'channel',
   ajaxOptions(urlToDecode, type, options = {}) {
     options = this._super(...arguments);

--- a/addon/adapters/channel.js
+++ b/addon/adapters/channel.js
@@ -1,9 +1,9 @@
 import DS from 'ember-data';
 import Ember from 'ember';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v3',
   pathForType: () => 'channel',
   ajaxOptions(urlToDecode, type, options = {}) {

--- a/addon/adapters/chunk.js
+++ b/addon/adapters/chunk.js
@@ -3,7 +3,7 @@ import ENV from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
   host: ENV.wnycAPI,
-  namespace: 'api/v3',
+  namespace: 'v3',
   buildURL() {
     let url = this._super(...arguments);
     return url + '/';

--- a/addon/adapters/chunk.js
+++ b/addon/adapters/chunk.js
@@ -1,8 +1,8 @@
 import DS from 'ember-data';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v3',
   buildURL() {
     let url = this._super(...arguments);

--- a/addon/adapters/comment.js
+++ b/addon/adapters/comment.js
@@ -8,7 +8,7 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   authorizer: 'authorizer:nypr',
   host: ENV.wnycAPI,
-  namespace: `api/v1/list/comments`,
+  namespace: 'v1/list/comments',
   
   query(store, type, query) {
     let url = [this.host, this.namespace, query.itemTypeId, query.itemId, ''].join('/');

--- a/addon/adapters/comment.js
+++ b/addon/adapters/comment.js
@@ -1,4 +1,4 @@
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import DS from 'ember-data';
 import wrapAjax from 'nypr-django-for-ember/utils/wrap-ajax'
 // TODO: auth headers for native fetch
@@ -7,7 +7,7 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   authorizer: 'authorizer:nypr',
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v1/list/comments',
   
   query(store, type, query) {

--- a/addon/adapters/playlist.js
+++ b/addon/adapters/playlist.js
@@ -3,7 +3,7 @@ import DS from 'ember-data';
 
 export default DS.JSONAPIAdapter.extend({
   host: ENV.wnycAPI,
-  namespace: 'api/v1',
+  namespace: 'v1',
   pathForType: () => 'stream_playlist',
   buildURL() {
     return this._super(...arguments) + '/';

--- a/addon/adapters/playlist.js
+++ b/addon/adapters/playlist.js
@@ -1,8 +1,8 @@
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import DS from 'ember-data';
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v1',
   pathForType: () => 'stream_playlist',
   buildURL() {

--- a/addon/adapters/show.js
+++ b/addon/adapters/show.js
@@ -3,7 +3,7 @@ import ENV from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
   host: ENV.wnycAPI,
-  namespace: 'api/v3',
+  namespace: 'v3',
   buildURL() {
     let url = this._super(...arguments);
     return url.replace(/([^/])$/, '$1/');

--- a/addon/adapters/show.js
+++ b/addon/adapters/show.js
@@ -1,8 +1,8 @@
 import DS from 'ember-data';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v3',
   buildURL() {
     let url = this._super(...arguments);

--- a/addon/adapters/story.js
+++ b/addon/adapters/story.js
@@ -1,4 +1,4 @@
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import DS from 'ember-data';
 import wrapAjax from 'nypr-publisher-lib/utils/wrap-ajax';
 // TODO: auth headers for native fetch
@@ -7,7 +7,7 @@ import wrapAjax from 'nypr-publisher-lib/utils/wrap-ajax';
 const DRAFT_TOKENS = ['content_type_id', 'object_id', 'token', '_'];
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v3',
   pathForType: () => 'story',
   buildURL() {

--- a/addon/adapters/story.js
+++ b/addon/adapters/story.js
@@ -8,7 +8,7 @@ const DRAFT_TOKENS = ['content_type_id', 'object_id', 'token', '_'];
 
 export default DS.JSONAPIAdapter.extend({
   host: ENV.wnycAPI,
-  namespace: 'api/v3',
+  namespace: 'v3',
   pathForType: () => 'story',
   buildURL() {
     return this._super(...arguments) + '/';

--- a/addon/adapters/stream.js
+++ b/addon/adapters/stream.js
@@ -5,7 +5,7 @@ import wrapAjax from 'nypr-publisher-lib/utils/wrap-ajax';
 
 export default DS.JSONAPIAdapter.extend({
   host: ENV.wnycAPI,
-  namespace: 'api/v1',
+  namespace: 'v1',
   findAll() {
     let streams, whatsOn;
     let streamUrl = [this.host, this.namespace, 'list/streams'].join('/') + '/';

--- a/addon/adapters/stream.js
+++ b/addon/adapters/stream.js
@@ -1,10 +1,10 @@
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import DS from 'ember-data';
 import rsvp from 'rsvp';
 import wrapAjax from 'nypr-publisher-lib/utils/wrap-ajax';
 
 export default DS.JSONAPIAdapter.extend({
-  host: ENV.wnycAPI,
+  host: config.publisherAPI,
   namespace: 'v1',
   findAll() {
     let streams, whatsOn;

--- a/addon/components/comments-form.js
+++ b/addon/components/comments-form.js
@@ -54,7 +54,7 @@ export default Component.extend({
       }
       let data = this.$().serialize();
       this.auth.then(({ security_hash, timestamp }) => {
-        let url = `${config.wnycAdminRoot}/comments/post/?bust_cache=${Math.random()}&id=${this.get('browserId')}`;
+        let url = `${config.adminRoot}/comments/post/?bust_cache=${Math.random()}&id=${this.get('browserId')}`;
         let story = this.get('story');
         let metaData = {
           content_type: 'cms.' + story.get('itemType'),

--- a/addon/components/nav-links.js
+++ b/addon/components/nav-links.js
@@ -23,10 +23,10 @@ export default Component.extend({
       // in development, we're usually running a copy of the prod DB which will
       // point to prod
       // in prod builds on demo or production, these values will point to our
-      // configured wnycURL
+      // configured webRoot
       origin = 'http://www.wnyc.org';
     } else {
-      origin = canonicalize(config.wnycURL);
+      origin = canonicalize(config.webRoot);
     }
     let links = Ember.A(get(this, 'links'));
     let navRoot = get(this, 'navRoot');

--- a/addon/components/story-comments.js
+++ b/addon/components/story-comments.js
@@ -6,7 +6,7 @@ import get from 'ember-metal/get';
 
 export default Component.extend({
   layout,
-  adminURL: `${config.wnycAdminRoot}/admin`,
+  adminURL: `${config.adminRoot}/admin`,
 
   comments: computed('getComments', {
     get() {

--- a/addon/components/story-list.js
+++ b/addon/components/story-list.js
@@ -7,5 +7,5 @@ export default Component.extend({
   layout,
   session: service(),
   tagName: 'section',
-  adminURL: `${config.wnycAdminRoot}/admin`
+  adminURL: `${config.adminRoot}/admin`
 });

--- a/addon/models/story.js
+++ b/addon/models/story.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import get, { getProperties } from 'ember-metal/get';
 import computed from 'ember-computed';
 import { producingOrgs } from 'nypr-publisher-lib/helpers/producing-orgs';
@@ -124,7 +124,7 @@ export default Model.extend({
     if (browserId) {
       data.id = browserId;
     }
-    return `${ENV.wnycAdminRoot}/comments/security_info/?${Ember.$.param(data)}`;
+    return `${config.adminRoot}/comments/security_info/?${Ember.$.param(data)}`;
   },
   nprAnalyticsDimensions: attr(),
   allProducingOrgs: computed('producingOrganizations', 'showProducingOrgs', function(){

--- a/addon/models/story.js
+++ b/addon/models/story.js
@@ -124,7 +124,7 @@ export default Model.extend({
     if (browserId) {
       data.id = browserId;
     }
-    return `${ENV.wnycAccountRoot}/comments/security_info/?${Ember.$.param(data)}`;
+    return `${ENV.wnycAdminRoot}/comments/security_info/?${Ember.$.param(data)}`;
   },
   nprAnalyticsDimensions: attr(),
   allProducingOrgs: computed('producingOrganizations', 'showProducingOrgs', function(){

--- a/addon/services/whats-on.js
+++ b/addon/services/whats-on.js
@@ -7,7 +7,7 @@ export default Service.extend({
   endPoint: 'v1/whats_on/',
   isLive(pk) {
     let endPoint = get(this, 'endPoint');
-    let url = `${config.wnycAPI}/${endPoint}`;
+    let url = `${config.publisherAPI}/${endPoint}`;
 
     return wrapAjax(url).then(d => this._extractStatus(d, pk));
   },

--- a/addon/services/whats-on.js
+++ b/addon/services/whats-on.js
@@ -1,17 +1,13 @@
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import wrapAjax from 'nypr-publisher-lib/utils/wrap-ajax';
 import Service from 'ember-service';
 import get from 'ember-metal/get';
-import { canonicalize } from 'nypr-django-for-ember/services/script-loader';
-
-let { wnycAPI } = ENV;
-wnycAPI = canonicalize(wnycAPI);
 
 export default Service.extend({
-  endPoint: 'api/v1/whats_on/',
+  endPoint: 'v1/whats_on/',
   isLive(pk) {
     let endPoint = get(this, 'endPoint');
-    let url = `${wnycAPI}${endPoint}`;
+    let url = `${config.wnycAPI}${endPoint}`;
 
     return wrapAjax(url).then(d => this._extractStatus(d, pk));
   },

--- a/addon/services/whats-on.js
+++ b/addon/services/whats-on.js
@@ -7,7 +7,7 @@ export default Service.extend({
   endPoint: 'v1/whats_on/',
   isLive(pk) {
     let endPoint = get(this, 'endPoint');
-    let url = `${config.wnycAPI}${endPoint}`;
+    let url = `${config.wnycAPI}/${endPoint}`;
 
     return wrapAjax(url).then(d => this._extractStatus(d, pk));
   },

--- a/tests/integration/components/nav-links-test.js
+++ b/tests/integration/components/nav-links-test.js
@@ -2,8 +2,8 @@ import config from 'ember-get-config';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { canonicalize  } from 'nypr-django-for-ember/services/script-loader';
-let { wnycURL } = config;
-wnycURL = canonicalize(wnycURL);
+let { webRoot } = config;
+webRoot = canonicalize(webRoot);
 
 moduleForComponent('nav-links', 'Integration | Component | nav links', {
   integration: true
@@ -24,7 +24,7 @@ test('it properly sets the activeTab if defaultTab is undefined', function(asser
 test('it properly parses incoming linkroll links', function(assert) {
 
   this.set('links', [
-    {href: `${wnycURL}foo/bar/`, title: 'Example'}
+    {href: `${webRoot}foo/bar/`, title: 'Example'}
   ]);
   this.render(hbs`{{nav-links links=links}}`);
   assert.equal(this.$('.is-active a').attr('href'), '/foo/bar/', 'links with matching origins have a leading slash');


### PR DESCRIPTION
Updates to better organize envvars and remove the `wnyc` prefix. Besides renaming, this removes the `wnycAccountRoot` envvar, because that is no longer a supported back end (account related requests can go to `adminRoot`). Also in the spirit of looking at Publisher as one of several microservices, this changes the value of the `wnycAPI` (renamed to `publisherAPI`) to include a path prefix. So the value will be `https://api.wnyc.org/api` instead of just `https://api.wnyc.org`.

Envvars renamed in this addon:
* `wnycAPI` -> `publisherAPI`
* `wnycAdminRoot` -> `adminRoot`
* `wnycURL` -> `webRoot`