### PR TITLE
GT-85 Update show title in story-tease so WNYC News is in data-show attribute

### DIFF
--- a/addon/components/story-tease.js
+++ b/addon/components/story-tease.js
@@ -20,6 +20,7 @@ export default Component.extend({
 
   status:             null,
   streamSlug:         null,
+  streamName:         null,
   isFeatured:         false,
 
   isLive:             equal('status', STATUSES.LIVE),
@@ -107,11 +108,12 @@ export default Component.extend({
   },
 
   _updateStatus(results) {
-    const [isLive, endtime, streamSlug] = results;
+    const [isLive, endtime, streamSlug, streamName] = results;
     if (isLive) {
       set(this, 'status', STATUSES.LIVE);
       set(this, 'endtime', endtime);
       set(this, 'streamSlug', streamSlug);
+      set(this, 'streamName', streamName);
     } else if (this._isUpcoming()){
       set(this, 'status', STATUSES.UPCOMING);
     } else {

--- a/addon/services/whats-on.js
+++ b/addon/services/whats-on.js
@@ -17,7 +17,7 @@ export default Service.extend({
     for (let i = 0; i < stations.length; i++) {
       let stationSlug = stations[i];
       let station = data[stationSlug];
-      let stationName = get(station, 'name');_
+      let stationName = get(station, 'name');
       // for some reason if the what's on story is an EPISODE, it's under episode_pk,
       // but if it's a SEGMENT, that pk is just on pk
       let onAirPk = get(station, 'current_show.episode_pk') || get(station, 'current_show.pk');

--- a/addon/services/whats-on.js
+++ b/addon/services/whats-on.js
@@ -17,13 +17,14 @@ export default Service.extend({
     for (let i = 0; i < stations.length; i++) {
       let stationSlug = stations[i];
       let station = data[stationSlug];
+      let stationName = get(station, 'name');_
       // for some reason if the what's on story is an EPISODE, it's under episode_pk,
       // but if it's a SEGMENT, that pk is just on pk
       let onAirPk = get(station, 'current_show.episode_pk') || get(station, 'current_show.pk');
       let endtime = get(station, 'current_show.end');
 
       if (String(onAirPk) === pk) {
-        return [true, endtime, stationSlug];
+        return [true, endtime, stationSlug, stationName];
       }
     }
 

--- a/addon/templates/components/story-tease.hbs
+++ b/addon/templates/components/story-tease.hbs
@@ -61,7 +61,8 @@
           playContext=playContext
           itemPK=itemId
           itemTitle=item.title
-          itemShow=(or item.showTitle item.headers.brand.title)}}
+          itemShow=(or item.showTitle item.headers.brand.title)
+          itemStream=streamName}}
           {{if isLive 'Listen Live' 'Listen'}}
           <span class="story-tease__duration">{{if isLive endtimeLabel item.audioDurationReadable}}</span>
 

--- a/addon/templates/components/story-tease.hbs
+++ b/addon/templates/components/story-tease.hbs
@@ -61,7 +61,7 @@
           playContext=playContext
           itemPK=itemId
           itemTitle=item.title
-          itemShow=item.showTitle}}
+          itemShow=(or item.showTitle item.headers.brand.title)}}
           {{if isLive 'Listen Live' 'Listen'}}
           <span class="story-tease__duration">{{if isLive endtimeLabel item.audioDurationReadable}}</span>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5524,8 +5524,6 @@ nypr-metrics@nypublicradio/nypr-metrics:
     ember-cli-babel "^6.0.0"
     ember-cli-htmlbars "^1.1.1"
     ember-cli-htmlbars-inline-precompile "^0.4.0"
-    ember-get-config "^0.2.2"
-    ember-metrics "^0.12.1"
 
 nypr-ui@nypublicradio/nypr-ui:
   version "0.0.0"


### PR DESCRIPTION
https://jira.wnyc.org/browse/GT-85
> - For WNYC News stories, the show name appears in the label on the "Pause" event but not on the "Played Story" event

For `listen-button` instances, we need to set `itemShow` to `headers.brand.title` when `showTitle` is not available, so that "WNYC News" is added to the button's `data-show` attribute where we can use it for GTM events.