### PR TITLE
Append bio to lede in appearance-list

### DIFF
--- a/addon/templates/components/appearance-list.hbs
+++ b/addon/templates/components/appearance-list.hbs
@@ -29,7 +29,7 @@
           <h2 class="team-person__type">
             {{appearance.appearanceType}}
           </h2>
-          <div class="team-person__bio">{{{truncate appearance.person.lede 150 '…'}}}</div>
+          <div class="team-person__bio">{{{truncate (concat appearance.person.bio appearance.person.lede) 150 '…'}}}</div>
           {{social-iconlist
             class="team-person__social-iconlist"
             links=appearance.socialLinks

--- a/addon/templates/components/appearance-list.hbs
+++ b/addon/templates/components/appearance-list.hbs
@@ -29,7 +29,7 @@
           <h2 class="team-person__type">
             {{appearance.appearanceType}}
           </h2>
-          <div class="team-person__bio">{{{truncate (concat appearance.person.bio appearance.person.lede) 150 '…'}}}</div>
+          <div class="team-person__bio">{{{truncate (concat appearance.person.lede appearance.person.bio) 150 '…'}}}</div>
           {{social-iconlist
             class="team-person__social-iconlist"
             links=appearance.socialLinks


### PR DESCRIPTION
if no bio exists, shows the lede.
if a bio exists, show that first.
either way, it gets truncated.

https://jira.wnyc.org/browse/GT-532