### PR TITLE
Show image on team tab when exactly 800px wide (or more)

### DIFF
--- a/addon/templates/components/appearance-list.hbs
+++ b/addon/templates/components/appearance-list.hbs
@@ -3,7 +3,7 @@
     <li class="appearance-list__list-item">
       <article class="team-person">
         {{#if (and appearance.person.image.template
-                   (gt appearance.person.image.w 800))}}
+                   (gte appearance.person.image.w 800))}}
           <div class="team-person__image-wrapper">
             {{#link-to 'person-detail' appearance.person.slug class="team-person__image-link" title=appearance.person.name ariaRole="presentation" ~}}
             <img class="team-person__image" alt=""


### PR DESCRIPTION
https://jira.wnyc.org/browse/GT-561