### PR TITLE
Camelize story attributes the same everywhere

### DIFF
--- a/addon/serializers/api-response.js
+++ b/addon/serializers/api-response.js
@@ -1,16 +1,19 @@
 import DS from 'ember-data';
 import { A } from '@ember/array';
+import { serializeStoryAttributes } from 'nypr-publisher-lib/serializers/story';
 
 export function serializeApiResponseRelationships(relationships = {}, included = []) {
   if (relationships['tease-list'] && relationships['tease-list'].data.length) {
     relationships['tease-list'].data.forEach(story => {
       let { attributes } = A(included).findBy('attributes.cms-pk', Number(story.id));
       story.id = attributes.slug;
+      serializeStoryAttributes(attributes);
     });
   }
   if (relationships.story && relationships.story.data) {
     let { attributes } = A(included).findBy('attributes.cms-pk', Number(relationships.story.data.id));
     relationships.story.data.id = attributes.slug;
+    serializeStoryAttributes(attributes);
   }
   return relationships;
 }

--- a/addon/serializers/bucket.js
+++ b/addon/serializers/bucket.js
@@ -1,6 +1,7 @@
 import JSONAPISerializer from 'ember-data/serializers/json-api';
 import { camelize } from '@ember/string';
 import { getWithDefault } from '@ember/object';
+import { serializeStoryAttributes } from 'nypr-publisher-lib/serializers/story';
 
 export default JSONAPISerializer.extend({
   extractId: (modelClass, {attributes}) => attributes.slug || "none",
@@ -13,6 +14,10 @@ export default JSONAPISerializer.extend({
         item.attributes = {};
         Object.keys(attributes)
           .forEach(k => item.attributes[camelize(k)] = attributes[k]);
+
+        if (item.type === 'story') {
+          serializeStoryAttributes(item.attributes);
+        }
       });
     }
     return this._super(...arguments);

--- a/addon/serializers/story.js
+++ b/addon/serializers/story.js
@@ -17,22 +17,23 @@ const propertiesWithChildren = [
 ];
 // END-SNIPPET
 
+// BEGIN-SNIPPET story-serializer
+export function serializeStoryAttributes(attributes) {
+  for (var prop of propertiesWithChildren) {
+    //if we have the property, process it
+    if (attributes && attributes.hasOwnProperty(prop)){
+      attributes[prop] = camelizeObject(attributes[prop]);
+    }
+  }
+}
+// END-SNIPPET
+
 export default DS.JSONAPISerializer.extend({
   extractId: (modelClass, {attributes}) => attributes.slug,
   payloadKeyFromModelName: () => 'story',
 
-  // BEGIN-SNIPPET story-serializer
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
-
-    for (var prop of propertiesWithChildren) {
-      //if we have the property, process it
-      if (payload.data.attributes && payload.data.attributes.hasOwnProperty(prop)){
-        payload.data.attributes[prop] = camelizeObject(payload.data.attributes[prop]);
-      }
-    }
-
+    serializeStoryAttributes(payload.data.attributes);
     return this._super(store, primaryModelClass, payload, id, requestType);
   },
-  // END-SNIPPET
-
 });

--- a/addon/templates/components/episode-list.hbs
+++ b/addon/templates/components/episode-list.hbs
@@ -25,8 +25,8 @@
           <div class="episode-tease__show-info">
             <a class="episode-tease__show-logo-link" href={{episode.headers.brand.url}} title={{episode.headers.brand.title}} aria-role="presentation">
               <img class="episode-tease__show-logo" alt=""
-                src="{{image-template episode.headers.brand.logo-image.template 41 41 episode.headers.brand.logo-image.crop}}"
-                srcset="{{image-template episode.headers.brand.logo-image.template 82 82 episode.headers.brand.logo-image.crop}} 2x">
+                src="{{image-template episode.headers.brand.logoImage.template 41 41 episode.headers.brand.logoImage.crop}}"
+                srcset="{{image-template episode.headers.brand.logoImage.template 82 82 episode.headers.brand.logoImage.crop}} 2x">
             </a>
             <h2 class="episode-tease__show-title">
               <a class="episode-tease__show-title-link" href={{episode.headers.brand.url}} title={{episode.headers.brand.title}}>


### PR DESCRIPTION
Certain attributes in the story model (headers, playlist, etc) have child attributes that need to be camel-cased after they get pulled in from the API. We do this for the story API, but we weren't doing this for stories that came from linkrolls or buckets.

This fixes that so a story should look the same no matter where it comes from.