### PR TITLE
GT-568 pagination fixes

### DIFF
--- a/addon/adapters/channel.js
+++ b/addon/adapters/channel.js
@@ -13,5 +13,15 @@ export default DS.JSONAPIAdapter.extend({
     return assign(options, {
       url: url.slice(-1) === '/' ? `${url}/` : url,
     });
-  }
+  },
+  urlForFindRecord(id, modelName, snapshot) {
+    let baseUrl = this.buildURL(modelName, id, snapshot);
+    if (snapshot.adapterOptions) {
+      let limit = (snapshot.adapterOptions.limit);
+      if (limit) {
+        baseUrl += `?limit=${limit}`;
+      }
+    }
+    return baseUrl;
+  },
 });

--- a/addon/models/api-response.js
+++ b/addon/models/api-response.js
@@ -42,9 +42,13 @@ export default DS.Model.extend({
   totalCount: DS.attr('number'),
   totalPages: computed('totalCount', {
     get() {
-      let length = get(this, 'teaseList.length') || get(this, 'appearances.length');
+      const responseLength = get(this, 'teaseList.length') || get(this, 'appearances.length');
       const total = get(this, 'totalCount');
-      return totalPages(total, length);
+      if (responseLength > 0) {
+        return totalPages(total, responseLength);
+      } else {
+        return totalPages(total);
+      }
     }
   }),
   // END-SNIPPET

--- a/addon/models/api-response.js
+++ b/addon/models/api-response.js
@@ -1,7 +1,6 @@
 import DS from 'ember-data';
 import { computed, get } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
-import { totalPages } from 'nypr-publisher-lib/utils/math-util';
 
 export default DS.Model.extend({
   // BEGIN-SNIPPET api-response-fields
@@ -40,16 +39,7 @@ export default DS.Model.extend({
     }
   }),
   totalCount: DS.attr('number'),
-  totalPages: computed('totalCount', {
-    get() {
-      const responseLength = get(this, 'teaseList.length') || get(this, 'appearances.length');
-      const total = get(this, 'totalCount');
-      if (responseLength > 0) {
-        return totalPages(total, responseLength);
-      } else {
-        return totalPages(total);
-      }
-    }
-  }),
+  totalPages: DS.attr('number'),
+  pageSize: DS.attr('number')
   // END-SNIPPET
 });

--- a/addon/models/api-response.js
+++ b/addon/models/api-response.js
@@ -42,8 +42,9 @@ export default DS.Model.extend({
   totalCount: DS.attr('number'),
   totalPages: computed('totalCount', {
     get() {
+      let length = get(this, 'teaseList.length') || get(this, 'appearances.length');
       const total = get(this, 'totalCount');
-      return totalPages(total);
+      return totalPages(total, length);
     }
   }),
   // END-SNIPPET


### PR DESCRIPTION
- Update api-response model to accept page totals from the api
- Update channel adapter to accept limit option

This depends on work in https://github.com/nypublicradio/publisher/tree/jj-api-pagination