### PR TITLE
Add api-response pagination logic to mirage factory

### DIFF
--- a/mirage-support/factories/api-response.js
+++ b/mirage-support/factories/api-response.js
@@ -7,4 +7,9 @@ export default Factory.extend({
   totalCount() {
     return this.teaseList ? this.teaseList.length : 0;
   },
+  pageSize: 10,
+  totalPages() {
+    let pages = Math.ceil(this.totalCount / this.pageSize);
+    return isNaN(pages) ? 0 : pages;
+  },
 });


### PR DESCRIPTION
Adds the api-response pagination logic that was moved out of the model (to the server) in v0.3.11 to the mirage factory for api-response, so client tests that depend on it don't fail.