### PR TITLE
Update active-html component to handle changes to HTML

### DIFF
--- a/addon/components/active-html.js
+++ b/addon/components/active-html.js
@@ -6,15 +6,23 @@ import { computed } from '@ember/object';
 export default Component.extend({
   layout,
   html: "",
-  isFastBoot: true,
+  loading: true,
   unescapedHTML: computed('html', function() {
      return this.get('html').replace(/\\x3C\/script>/g, '</script>');
   }),
   didInsertElement() {
-    this.set('isFastBoot', false)
+    this.set('loading', false)
     let html = this.get('unescapedHTML');
     let element = this.$();
     // element.empty();
+    schedule('render', () => {
+      element.append(html);
+    });
+  },
+  didUpdateAttrs() {
+    let html = this.get('unescapedHTML');
+    let element = this.$();
+    element.empty();
     schedule('render', () => {
       element.append(html);
     });

--- a/addon/components/active-html.js
+++ b/addon/components/active-html.js
@@ -6,22 +6,19 @@ import { computed } from '@ember/object';
 export default Component.extend({
   layout,
   html: "",
-  loading: true,
   unescapedHTML: computed('html', function() {
      return this.get('html').replace(/\\x3C\/script>/g, '</script>');
   }),
   didInsertElement() {
-    this.set('loading', false)
     let html = this.get('unescapedHTML');
-    let element = this.$();
-    // element.empty();
+    let element = this.$('.html');
     schedule('render', () => {
       element.append(html);
     });
   },
   didUpdateAttrs() {
     let html = this.get('unescapedHTML');
-    let element = this.$();
+    let element = this.$('.html');
     element.empty();
     schedule('render', () => {
       element.append(html);

--- a/addon/templates/components/active-html.hbs
+++ b/addon/templates/components/active-html.hbs
@@ -1,4 +1,1 @@
-{{#if loading}}
-  <div class="html-content__loading"></div>
-{{/if}}
-{{yield}}
+<div class="html"></div>

--- a/addon/templates/components/active-html.hbs
+++ b/addon/templates/components/active-html.hbs
@@ -1,4 +1,4 @@
-{{#if isFastBoot}}
+{{#if loading}}
   <div class="html-content__loading"></div>
 {{/if}}
 {{yield}}

--- a/tests/integration/components/active-html-test.js
+++ b/tests/integration/components/active-html-test.js
@@ -26,5 +26,16 @@ module('Integration | Component | active-html', function(hooks) {
     let contents = this.$('#target');
     assert.equal(contents.text().trim(), 'changed');
   });
+
+  test('it handles changes to html', async function(assert) {
+    let html = '<div class="target">test</div>'
+    this.set('html', html);
+    await render(hbs`{{active-html html=html}}`);
+
+    let html2 = '<div class="target2">test2</div>'
+    this.set('html', html2);
+    let contents = this.$('.target2');
+    assert.equal(contents.text().trim(), 'test2');
+  });
 });
 


### PR DESCRIPTION
`active-html` a component used currently on studios as a replacement for `django-page` that does less things and doesn't break FastBoot. 

This change fixes an issue where it wouldn't update if the `html` being passed into it was changed. It also removes a load state tracking div that was never used.