### PR TITLE
use stream.liveOnAny to build /streams list MT-91 MT-92

### DIFF
--- a/addon/models/stream.js
+++ b/addon/models/stream.js
@@ -41,12 +41,16 @@ export default Model.extend({
     return get(this, 'sourceTags').includes('wnyc_site');
   }),
 
-  liveWQXR:             computed('isWQXR', 'whatsOn', 'alwaysBroadcasting', function(){
-    return get(this, 'isWQXR') && ((get(this, 'whatsOn') > 0) || (get(this, 'alwaysBroadcasting')));
+  liveOnAny:            computed('whatsOn', 'alwaysBroadcasting', function() {
+    return ((get(this, 'whatsOn') > 0) || (get(this, 'alwaysBroadcasting')));
   }),
 
-  liveWNYC:             computed('isWNYC', 'whatsOn', 'alwaysBroadcasting', function(){
-    return get(this, 'isWNYC') && ((get(this, 'whatsOn') > 0) || (get(this, 'alwaysBroadcasting')));
+  liveWQXR:             computed('isWQXR', 'liveOnAny', function(){
+    return get(this, 'isWQXR') && get(this, 'liveOnAny');
+  }),
+
+  liveWNYC:             computed('isWNYC', 'liveOnAny', function(){
+    return get(this, 'isWNYC') && get(this, 'liveOnAny');
   }),
 
   currentComposer:      computed('currentPlaylistItem', function() {

--- a/addon/templates/components/stream-list.hbs
+++ b/addon/templates/components/stream-list.hbs
@@ -1,5 +1,5 @@
 {{#each streams as |stream|}}
-{{#if stream.whatsOn}}
+{{#if stream.liveOnAny}}
 
 {{#holygrail-layout tagName='li' class='streamitem' as |g|}}
   {{#g.left}}


### PR DESCRIPTION
This PR adds a new computed stream property `stream.liveOnAny` that returns true if a stream either has `whatsOn` playlist info or is set as `alwaysBroadcasting`, then uses the new prop to determine which streams to list on the /streams pages. 
