### PR TITLE
WNYC-191 Add and configure HLS as the preferred playback format

### DIFF
--- a/addon/serializers/stream.js
+++ b/addon/serializers/stream.js
@@ -133,9 +133,7 @@ export default DS.JSONAPISerializer.extend({
         ios     : userAgent.indexOf('iPhone') > -1 || userAgent.indexOf('iPad') > -1
       };
     }
-    let {
-      /*ipod:hls,*/ // no HLS until CDN servers are working correctly
-      aac, rtsp:mp3, mobile_aac, mobile:mobile_mp3 } = urls;
+    let { ipod:hls, aac, rtsp:mp3, mobile_aac, mobile:mobile_mp3 } = urls;
 
     // why is this an array?
     aac = aac[0];
@@ -148,10 +146,10 @@ export default DS.JSONAPISerializer.extend({
 
       // only offer aac streams on mobile for now until HLS servers are working
       // also: the mp3 mount point does not have an extension
-      return [aac, {url: mp3, mimeType: 'audio/mpeg'}];
+      return [hls, aac, {url: mp3, mimeType: 'audio/mpeg'}];
     } else {
       // the mp3 mount point does not have an extension
-      return [{url: mp3, mimeType: 'audio/mpeg'}, aac];
+      return [hls, {url: mp3, mimeType: 'audio/mpeg'}, aac];
     }
   }
   // END-SNIPPET


### PR DESCRIPTION
This ticket added the HLS stream format to those already contained in the stream.urls list and makes it the first URL in the list, which means that the consuming client should attempt to play it before the others. 

https://jira.wnyc.org/browse/WNYC-191
