### PR TITLE
WQXR-196 default current_playlist_item, previous, and future to empty values

### DIFF
--- a/addon/serializers/stream.js
+++ b/addon/serializers/stream.js
@@ -100,16 +100,17 @@ export default DS.JSONAPISerializer.extend({
     }
     if (current_playlist_item) {
       attributes.current_playlist_item = camelizeKeys([ current_playlist_item ]);
+    } else {
+      attributes.current_playlist_item = null;
     }
+    attributes.future = [];
     if (future) {
-      attributes.future = [];
       future.forEach((p, i) => attributes.future[i] = camelizeKeys([ p ]));
     }
+    attributes.previous = [];
     if (previous) {
-      attributes.previous = [];
       previous.forEach((p, i) => attributes.previous[i] = camelizeKeys([ p ]));
     }
-
     json.attributes = attributes;
     json.relationships = relationships;
     return json;


### PR DESCRIPTION
Fix a bug where publisher lib fails to clear the current playlist item attribute when a track moves to the previous list and an air break occurs, resulting in previous[0] being the same as current_playlist_item until the air break ends and a new track starts.