### PR TITLE
Update google publisher tag url

### DIFF
--- a/mirage-support/helpers/django-html.js
+++ b/mirage-support/helpers/django-html.js
@@ -1074,7 +1074,7 @@ var HTML = `<html>
         var gads = document.createElement('script');
         gads.async = true; gads.type = 'text/javascript';
         var useSSL = 'https:' == document.location.protocol;
-        gads.src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';
+        gads.src = (useSSL ? 'https:' : 'http:') + '//securepubads.g.doubleclick.net/tag/js/gpt.js';
         var node = document.getElementsByTagName('script')[0];
         node.parentNode.insertBefore(gads, node);
       })();


### PR DESCRIPTION
Use the correct url to load the Google Publisher Tags script.
https://developers.google.com/publisher-tag/guides/general-best-practices#load_from_an_official_source